### PR TITLE
Including filter to show only region-specific earthquakes

### DIFF
--- a/app/src/main/java/com/theQuake/quakeInfo/EarthquakeActivity.java
+++ b/app/src/main/java/com/theQuake/quakeInfo/EarthquakeActivity.java
@@ -230,7 +230,7 @@ public class EarthquakeActivity extends AppCompatActivity implements LoaderCallb
         Uri.Builder uriBuilder = baseUri.buildUpon();
 
         uriBuilder.appendQueryParameter("format", "geojson");
-        uriBuilder.appendQueryParameter("limit", "10");
+        uriBuilder.appendQueryParameter("limit", "100");
         uriBuilder.appendQueryParameter("minmag", minMagnitude);
         uriBuilder.appendQueryParameter("orderby", orderBy);
 
@@ -239,6 +239,9 @@ public class EarthquakeActivity extends AppCompatActivity implements LoaderCallb
 
     @Override
     public void onLoadFinished(Loader<List<Earthquake>> loader, List<Earthquake> earthquakes) {
+
+        SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
+
         // Hide loading indicator because the data has been loaded
         View loadingIndicator = findViewById(R.id.loading_indicator);
         loadingIndicator.setVisibility(View.GONE);
@@ -246,13 +249,20 @@ public class EarthquakeActivity extends AppCompatActivity implements LoaderCallb
         // Set empty state text to display "No earthquakes found."
         mEmptyStateTextView.setText(R.string.no_earthquakes);
 
+        String region = sharedPrefs.getString(
+                getString(R.string.settings_narrow_by_region_key),
+                getString(R.string.settings_narrow_by_region_default)
+        );
+
+        List<Earthquake> filteredByRegionEarthquake = Utils.filterByRegion(earthquakes, region);
+
         // Clear the adapter of previous earthquake data
         mAdapter.clear();
 
         // If there is a valid list of {@link Earthquake}s, then add them to the adapter's
         // data set. This will trigger the ListView to update.
-        if (earthquakes != null && !earthquakes.isEmpty()) {
-            mAdapter.addAll(earthquakes);
+        if (filteredByRegionEarthquake != null && !filteredByRegionEarthquake.isEmpty()) {
+            mAdapter.addAll(filteredByRegionEarthquake);
         }
     }
 

--- a/app/src/main/java/com/theQuake/quakeInfo/SettingsActivity.java
+++ b/app/src/main/java/com/theQuake/quakeInfo/SettingsActivity.java
@@ -34,6 +34,9 @@ public class SettingsActivity extends AppCompatActivity {
 
             Preference orderBy = findPreference(getString(R.string.settings_order_by_key));
             bindPreferenceSummaryToValue(orderBy);
+
+            Preference narrowByRegion = findPreference(getString(R.string.settings_narrow_by_region_key));
+            bindPreferenceSummaryToValue(narrowByRegion);
         }
 
         @Override

--- a/app/src/main/java/com/theQuake/quakeInfo/Utils.java
+++ b/app/src/main/java/com/theQuake/quakeInfo/Utils.java
@@ -1,0 +1,18 @@
+package com.theQuake.quakeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class Utils {
+    public static List<Earthquake> filterByRegion(List<Earthquake> earthquakes, String region) {
+        List<Earthquake> filteredByRegionEarthquake = new ArrayList<>();
+
+        for(int i = 0; i < earthquakes.size(); i++){
+            if(earthquakes.get(i).getLocation().contains(region)){
+                filteredByRegionEarthquake.add(earthquakes.get(i));
+            }
+        }
+
+        return filteredByRegionEarthquake;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,11 @@
     <string name="settings_min_magnitude_key" translatable="false">min_magnitude</string>
     <string name="settings_min_magnitude_default" translatable="false">6</string>
 
+    <!-- Strings For Narrow by Region Preference [CHAR LIMIT=NONE] -->
+    <string name="settings_narrow_by_region_label">Narrow by Region</string>
+    <string name="settings_narrow_by_region_key" translatable="false">narrow_by_region</string>
+    <string name="settings_narrow_by_region_default" translatable="false">Japan</string>
+
     <!-- Strings For Order-By Preference [CHAR LIMIT=30] -->
     <string name="settings_order_by_label">Order By</string>
     <string name="settings_order_by_key" translatable="false">order_by</string>

--- a/app/src/main/res/xml/settings_main.xml
+++ b/app/src/main/res/xml/settings_main.xml
@@ -17,4 +17,11 @@
         android:selectAllOnFocus="true"
         android:title="@string/settings_min_magnitude_label" />
 
+    <EditTextPreference
+        android:defaultValue="@string/settings_narrow_by_region_default"
+        android:inputType="text"
+        android:key="@string/settings_narrow_by_region_key"
+        android:selectAllOnFocus="true"
+        android:title="@string/settings_narrow_by_region_label" />
+
 </PreferenceScreen>


### PR DESCRIPTION
PR to resolve issue #8  

I made the solution considering these scenario:

1. I have a default region
2. I fetch data from API using order and magnitude parameters (allowed by the api)
3. In the callback of the preferences loader I added a call to a method that filters by region, setted in preferences as well (this is not allowed directly by the API)
4. With the filtered list, I call the adapter to change the view with the correct data wanted